### PR TITLE
Remove duplicate Google Fonts links

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>אודות | חוי שיינברגר</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/png" href="favicon.png">
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,10 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>צור קשר - חוי שיינברגר</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="favicon.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>חוי שיינברגר - אתר אישי</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/png" href="favicon.png">
 </head>

--- a/services.html
+++ b/services.html
@@ -3,10 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>השירותים שלי – חוי שיינברגר</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="favicon.png" type="image/png">
-<link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/testimonials.html
+++ b/testimonials.html
@@ -3,10 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>המלצות - חוי שיינברגר</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="favicon.png" type="image/png">
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/thankyou.html
+++ b/thankyou.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>תודה – חוי שיינברגר</title>
-  <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="favicon.png" type="image/png">
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary
- remove extra Google Fonts tags
- rely on `style.css` for font import on all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c029114508330abc5cb9a18dc6c86