### PR TITLE
Merge about section into home page hero

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
     <nav>
       <ul>
         <li><a href="index.html">דף הבית</a></li>
-        <li><a href="about.html" class="active">אודות</a></li>
+        <li><a href="index.html#about">אודות</a></li>
         <li><a href="services.html">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>

--- a/contact.html
+++ b/contact.html
@@ -15,7 +15,7 @@
     <nav>
       <ul>
         <li><a href="index.html">דף הבית</a></li>
-        <li><a href="about.html">אודות</a></li>
+        <li><a href="index.html#about">אודות</a></li>
         <li><a href="services.html">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <nav>
       <ul>
         <li><a href="index.html" class="active">דף הבית</a></li>
-        <li><a href="about.html">אודות</a></li>
+        <li><a href="#about">אודות</a></li>
         <li><a href="services.html">שירותים</a></li>
         <li><a href="#gallery">גלריה</a></li>
         <li><a href="#testimonials">המלצות</a></li>
@@ -25,14 +25,21 @@
     </nav>
   </header>
 
-<main class="hero-section">
-  <div class="hero-content">
-    <h1>חוי שיינברגר</h1>
-    <p class="subtitle">את בידיים טובות</p>
-    <p class="description">עיסוי מקצועי, קורסי הכנה ללידה וליווי רגשי לנשים בלבד</p>
-    <a href="contact.html" class="btn-primary">לתיאום במייל</a>
-  </div>
-</main>
+  <main class="hero-section">
+    <div class="hero-content">
+      <h1>חוי שיינברגר</h1>
+      <p class="subtitle">את בידיים טובות</p>
+      <p class="description">עיסוי מקצועי, קורסי הכנה ללידה וליווי רגשי לנשים בלבד</p>
+      <a href="contact.html" class="btn-primary">לתיאום במייל</a>
+    </div>
+
+    <div id="about" class="about-overlay">
+      <p>שמי חוי שיינברגר, ואני עוסקת בטיפול וליווי לנשים בלבד – כבר מעל לעשור.</p>
+      <p>כמעסה רפואית מוסמכת ודולה מקצועית, אני מלווה נשים בתקופות הרגישות ביותר בחייהן – לקראת לידה, בהתמודדות עם כאבים, או בתקופות נפשיות מאתגרות.</p>
+      <p>אני מאמינה במגע עדין, הקשבה עמוקה, ואווירה של ביטחון, שמאפשרים שחרור רגשי ופיזי – גם לנשים דתיות וחרדיות, בגישה שמכבדת ומכילה כל אחת באשר היא.</p>
+      <p>הליווי שלי הוא אישי, רגשי ומקצועי – עם סבלנות, דיסקרטיות וצניעות. את לא לבד. אני כאן בשבילך.</p>
+    </div>
+  </main>
 
 <section class="services-section">
   <h2>השירותים שלי</h2>

--- a/services.html
+++ b/services.html
@@ -17,7 +17,7 @@
     <nav>
       <ul>
         <li><a href="index.html">דף הבית</a></li>
-        <li><a href="about.html">אודות</a></li>
+        <li><a href="index.html#about">אודות</a></li>
         <li><a href="services.html" class="active">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>

--- a/style.css
+++ b/style.css
@@ -79,8 +79,9 @@ p {
 /* Hero */
 .hero-section {
   background: url('images/hero.jpg') center/cover no-repeat;
-  min-height: 80vh;
+  min-height: 100vh;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
@@ -88,10 +89,25 @@ p {
 }
 
 .hero-content {
-  background-color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(255, 255, 255, 0.75);
   padding: 30px 40px;
   border-radius: 12px;
   max-width: 600px;
+}
+.hero-content p {
+  line-height: 1.6;
+}
+
+.about-overlay {
+  background-color: rgba(255, 255, 255, 0.75);
+  margin-top: 30px;
+  padding: 20px 30px;
+  border-radius: 12px;
+  max-width: 700px;
+  line-height: 1.6;
+}
+.about-overlay p {
+  margin: 0 0 10px;
 }
 
 .hero-content h1 {

--- a/thankyou.html
+++ b/thankyou.html
@@ -15,7 +15,7 @@
     <nav>
       <ul>
         <li><a href="index.html">דף הבית</a></li>
-        <li><a href="about.html">אודות</a></li>
+        <li><a href="index.html#about">אודות</a></li>
         <li><a href="services.html">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>


### PR DESCRIPTION
## Summary
- integrate the "About" content inside the home page hero section
- style new about overlay and adjust hero layout
- update navigation on all pages to link to the new about section
- refine overlay transparency and typography, remove redundant heading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d1e418bd48330a9863caaaa3640f3