### PR TITLE
Update navigation and hero layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,10 +16,10 @@
       <ul>
         <li><a href="index.html">דף הבית</a></li>
         <li><a href="index.html#about">אודות</a></li>
-        <li><a href="services.html">שירותים</a></li>
+        <li><a href="index.html#services">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>
-        <li><a href="contact.html">צור קשר</a></li>
+        <li><a href="index.html#contact">צור קשר</a></li>
       </ul>
     </nav>
   </header>

--- a/contact.html
+++ b/contact.html
@@ -16,10 +16,10 @@
       <ul>
         <li><a href="index.html">דף הבית</a></li>
         <li><a href="index.html#about">אודות</a></li>
-        <li><a href="services.html">שירותים</a></li>
+        <li><a href="index.html#services">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>
-        <li><a href="contact.html" class="active">צור קשר</a></li>
+        <li><a href="index.html#contact" class="active">צור קשר</a></li>
       </ul>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Varela+Round&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.rtl.min.css" rel="stylesheet" integrity="sha384-4w4pNv2XdLT2A0i2Ghqy5MzZY1o5LZiN5N4dAJE1lghYzBL2cJlgd5tbhbcL1wQP" crossorigin="anonymous">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
   <link href="https://unpkg.com/aos@next/dist/aos.css" rel="stylesheet">
@@ -24,10 +25,10 @@
         <ul class="nav">
           <li class="nav-item"><a href="index.html" class="nav-link active"><i class="fa-solid fa-house"></i> דף הבית</a></li>
           <li class="nav-item"><a href="#about" class="nav-link"><i class="fa-solid fa-info-circle"></i> אודות</a></li>
-          <li class="nav-item"><a href="services.html" class="nav-link"><i class="fa-solid fa-hand-holding-medical"></i> שירותים</a></li>
+          <li class="nav-item"><a href="#services" class="nav-link"><i class="fa-solid fa-hand-holding-medical"></i> שירותים</a></li>
           <li class="nav-item"><a href="#gallery" class="nav-link"><i class="fa-solid fa-image"></i> גלריה</a></li>
           <li class="nav-item"><a href="#testimonials" class="nav-link"><i class="fa-solid fa-comments"></i> המלצות</a></li>
-          <li class="nav-item"><a href="contact.html" class="nav-link"><i class="fa-solid fa-envelope"></i> צור קשר</a></li>
+          <li class="nav-item"><a href="#contact" class="nav-link"><i class="fa-solid fa-envelope"></i> צור קשר</a></li>
         </ul>
       </nav>
     </div>
@@ -38,7 +39,7 @@
       <h1>חוי שיינברגר</h1>
       <p class="subtitle">את בידיים טובות</p>
       <p class="description">עיסוי מקצועי, קורסי הכנה ללידה וליווי רגשי לנשים בלבד</p>
-      <a href="contact.html" class="btn-primary">לתיאום במייל</a>
+      <a href="#contact" class="btn-primary">לתיאום במייל</a>
     </div>
 
     <div id="about" class="about-overlay" data-aos="fade-left">
@@ -50,7 +51,7 @@
     </div>
   </main>
 
-<section class="services-section">
+<section id="services" class="services-section">
   <div class="container">
     <h2 class="mb-4">השירותים שלי</h2>
 
@@ -151,6 +152,23 @@
       <div style="margin-top: 30px;">
         <a href="https://www.google.com/maps/place/%D7%97%D7%95%D7%99+%D7%A9%D7%99%D7%99%D7%A0%D7%91%D7%A8%D7%92%D7%A8+-+%D7%A2%D7%99%D7%A1%D7%95%D7%99+%D7%9E%D7%A7%D7%A6%D7%95%D7%A2%D7%99+%D7%9C%D7%A0%D7%A9%D7%99%D7%9D+%D7%91%D7%9C%D7%91%D7%93+%D7%95%D7%AA%D7%95%D7%9E%D7%9B%D7%AA+%D7%9C%D7%99%D7%93%D7%94" target="_blank" class="btn-primary">עוד המלצות בגוגל</a>
       </div>
+    </div>
+  </section>
+
+  <section id="contact" class="contact-section">
+    <div class="container">
+      <h2>צור קשר</h2>
+      <p>לתיאום או שאלה, ניתן לפנות במייל:</p>
+      <p><a href="mailto:ch0527656654@gmail.com">ch0527656654@gmail.com</a></p>
+      <form class="contact-form" action="mailto:ch0527656654@gmail.com" method="POST" enctype="text/plain">
+        <label for="name">שם מלא:</label>
+        <input type="text" id="name" name="name" required>
+        <label for="email">אימייל:</label>
+        <input type="email" id="email" name="email" required>
+        <label for="message">הודעה:</label>
+        <textarea id="message" name="message" rows="5" required></textarea>
+        <button type="submit" class="btn-primary">שלח/י הודעה</button>
+      </form>
     </div>
   </section>
 

--- a/services.html
+++ b/services.html
@@ -18,10 +18,10 @@
       <ul>
         <li><a href="index.html">דף הבית</a></li>
         <li><a href="index.html#about">אודות</a></li>
-        <li><a href="services.html" class="active">שירותים</a></li>
+        <li><a href="index.html#services" class="active">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>
-        <li><a href="contact.html">צור קשר</a></li>
+        <li><a href="index.html#contact">צור קשר</a></li>
       </ul>
     </nav>
   </header>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Assistant:wght@400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Varela+Round&display=swap');
 
 body {
   margin: 0;
@@ -36,6 +37,10 @@ p {
 
 .logo-container img {
   height: 60px;
+}
+
+.main-header nav {
+  margin-right: auto;
 }
 
 .main-header nav ul {
@@ -91,7 +96,7 @@ p {
 
 .hero-content {
   background-color: rgba(255, 255, 255, 0.8);
-  padding: 30px 40px;
+  padding: 20px 30px;
   border-radius: 12px;
   max-width: 500px;
 }
@@ -99,11 +104,12 @@ p {
 .about-overlay {
   background-color: rgba(255, 255, 255, 0.85);
   margin-top: 0;
-  padding: 20px 30px;
+  padding: 15px 25px;
   border-radius: 12px;
   max-width: 500px;
-  line-height: 1.8;
+  line-height: 1.6;
   text-align: right;
+  font-family: 'Varela Round', sans-serif;
 }
 
 .hero-content h1 {
@@ -120,6 +126,7 @@ p {
 .hero-content .description {
   font-size: 16px;
   margin-bottom: 20px;
+  line-height: 1.6;
 }
 
 .btn-primary {
@@ -394,6 +401,34 @@ p {
   width: 100%;
   height: 450px;
   border: 0;
+}
+
+/* Contact */
+.contact-section {
+  background-color: #fef9f6;
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.contact-form {
+  max-width: 500px;
+  margin: 20px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-family: inherit;
+}
+
+.contact-form button {
+  align-self: center;
+  margin-top: 10px;
 }
 
 @media screen and (max-width: 768px) {

--- a/thankyou.html
+++ b/thankyou.html
@@ -16,10 +16,10 @@
       <ul>
         <li><a href="index.html">דף הבית</a></li>
         <li><a href="index.html#about">אודות</a></li>
-        <li><a href="services.html">שירותים</a></li>
+        <li><a href="index.html#services">שירותים</a></li>
         <li><a href="index.html#gallery">גלריה</a></li>
         <li><a href="index.html#testimonials">המלצות</a></li>
-        <li><a href="contact.html" class="active">צור קשר</a></li>
+        <li><a href="index.html#contact" class="active">צור קשר</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- link to new sections instead of old pages
- shrink hero content and about overlay spacing
- add friendly Varela Round font
- new contact section on the home page
- move navigation to the left via CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d638450c08330a021e415d61b97ec