### PR TITLE
Fix testimonial slider navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
     <div class="container">
       <h2>לקוחות מספרות</h2>
       <div class="testimonials-carousel" data-aos="fade-up">
-        <button class="testimonial-arrow left">&#10094;</button>
+        <button class="testimonial-arrow left"><i class="fa-solid fa-chevron-left"></i></button>
         <div class="testimonial-track">
         <blockquote class="testimonial">
           <p>"חוי פשוט מדהימה! יצאתי מהעיסוי חדשה."</p>
@@ -147,7 +147,7 @@
           <footer>– שושי</footer>
         </blockquote>
       </div>
-        <button class="testimonial-arrow right">&#10095;</button>
+        <button class="testimonial-arrow right"><i class="fa-solid fa-chevron-right"></i></button>
       </div>
       <div style="margin-top: 30px;">
         <a href="https://www.google.com/maps/place/%D7%97%D7%95%D7%99+%D7%A9%D7%99%D7%99%D7%A0%D7%91%D7%A8%D7%92%D7%A8+-+%D7%A2%D7%99%D7%A1%D7%95%D7%99+%D7%9E%D7%A7%D7%A6%D7%95%D7%A2%D7%99+%D7%9C%D7%A0%D7%A9%D7%99%D7%9D+%D7%91%D7%9C%D7%91%D7%93+%D7%95%D7%AA%D7%95%D7%9E%D7%9B%D7%AA+%D7%9C%D7%99%D7%93%D7%94" target="_blank" class="btn-primary">עוד המלצות בגוגל</a>
@@ -231,7 +231,8 @@
       let currTesti = 0;
 
       function updateTesti() {
-        testiTrack.style.transform = `translateX(${-currTesti * 100}%)`;
+        const slideWidth = testiTrack.parentElement.offsetWidth;
+        testiTrack.style.transform = `translateX(${-currTesti * slideWidth}px)`;
       }
 
       updateTesti();
@@ -249,6 +250,7 @@
           updateTesti();
         }
       });
+      window.addEventListener("resize", updateTesti);
     }
   });
 </script>

--- a/style.css
+++ b/style.css
@@ -328,6 +328,7 @@ p {
 }
 
 .testimonials-carousel {
+  direction: ltr;
   position: relative;
   max-width: 800px;
   margin: auto;


### PR DESCRIPTION
## Summary
- show testimonials left to right
- swap testimonial arrow icons
- fix JS slide width calculation

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d6a02d8b08330860f34218179f9a7