### PR TITLE
Add full_logo image to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
   <main class="hero-section">
     <div class="hero-content" data-aos="fade-right">
-      <h1>חוי שיינברגר</h1>
+      <img src="images/full_logo.png" alt="לוגו חוי שיינברגר" class="full-logo">
       <p class="subtitle">את בידיים טובות</p>
       <p class="description">עיסוי מקצועי, קורסי הכנה ללידה וליווי רגשי לנשים בלבד</p>
       <a href="#contact" class="btn-primary">לתיאום במייל</a>

--- a/style.css
+++ b/style.css
@@ -87,10 +87,10 @@ p {
 .hero-section {
   background: url('images/hero.jpg') center/cover no-repeat;
   min-height: 100vh;
-  display: grid;
-  grid-template-columns: auto 1fr;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  text-align: right;
+  text-align: center;
   padding: 40px;
   gap: 40px;
 }
@@ -100,7 +100,14 @@ p {
   padding: 20px 30px;
   border-radius: 12px;
   max-width: 300px;
-  justify-self: center;
+  align-self: center;
+  text-align: center;
+}
+
+.full-logo {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 15px;
 }
 
 .about-overlay {
@@ -110,9 +117,9 @@ p {
   border-radius: 12px;
   max-width: 500px;
   line-height: 1.6;
-  text-align: right;
+  text-align: center;
   font-family: 'Varela Round', sans-serif;
-  justify-self: end;
+  align-self: center;
 }
 
 .hero-content h1 {


### PR DESCRIPTION
## Summary
- swap text header for `full_logo.png`
- convert hero section layout to flex column
- center and style hero/about blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d82784d6c8330afe6f405a1b453fb